### PR TITLE
Expose remote interface to get the current queue

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -286,3 +286,19 @@ script.on_nth_tick(60, function()
     ::continue::
   end
 end)
+
+remote.add_interface("urq", {
+  get_queue = function(force)
+    local force_id = game.forces[force].index
+    if not storage.forces[force_id] or not storage.forces[force_id].queue then
+      return {}
+    end
+    local queue = {}
+    local node = storage.forces[force_id].queue.head
+    for i = 1, storage.forces[force_id].queue.len do
+      queue[i] = node.technology
+      node = node.next
+    end
+    return queue
+  end
+})


### PR DESCRIPTION
The interface is accessible with `remote.call("urq", "get_queue", force)` where `force` is either the index or name of the desired Force. The queue is returned in the same format as `force.research_queue`, which is as an array of `LuaTechnology`s.

Resolves #11