### PR TITLE
Open items in Factoriopedia instead of the discontinued Recipe Book

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.3
+Date: 2026-07-14
+  Changes:
+    - Fixed: alt+clicking items, recipes, and other effects in the technology info panel now opens the base-game Factoriopedia instead of the no-longer-updated Recipe Book
+    - Removed the optional Recipe Book dependency
+---------------------------------------------------------------------------------------------------
 Version: 2.1.2
 Date: 2026-07-11
   Changes:

--- a/gui-util.lua
+++ b/gui-util.lua
@@ -48,8 +48,8 @@ function gui_util.effect_button(effect, show_controls)
   elseif effect.type == "give-item" then
     sprite = "item/" .. effect.item
     elem_tooltip = { type = "item", name = effect.item }
-    if show_controls and script.active_mods["RecipeBook"] then
-      tooltip = { "gui.urq-tooltip-view-in-recipe-book" }
+    if show_controls then
+      tooltip = { "gui.urq-tooltip-view-in-factoriopedia" }
     end
   elseif effect.type == "gun-speed" then
     sprite = storage.effect_icons[effect.ammo_category]
@@ -71,8 +71,8 @@ function gui_util.effect_button(effect, show_controls)
   elseif effect.type == "unlock-recipe" then
     sprite = "recipe/" .. effect.recipe
     elem_tooltip = { type = "recipe", name = effect.recipe }
-    if show_controls and script.active_mods["RecipeBook"] then
-      tooltip = { "gui.urq-tooltip-view-in-recipe-book" }
+    if show_controls then
+      tooltip = { "gui.urq-tooltip-view-in-factoriopedia" }
     end
   elseif effect.type == "unlock-space-location" then
     sprite = "space-location/" .. effect.space_location

--- a/gui.lua
+++ b/gui.lua
@@ -347,20 +347,20 @@ end
 
 --- @param self Gui
 --- @param e EventData.on_gui_click
-function gui.open_in_recipe_book(self, e)
-  if not script.active_mods["RecipeBook"] or not e.alt then
+function gui.open_in_factoriopedia(self, e)
+  if not e.alt or not e.element.sprite then
     return
   end
   local class, name = string.match(e.element.sprite, "(.*)/(.*)")
-  local prototype = nil
-  if class == "recipe" then
-    prototype = prototypes.recipe[name]
-  elseif class == "item" then
-    prototype = prototypes.item[name]
-  else
+  if not class or not name then
     return
   end
-  remote.call("RecipeBook", "open_page", self.player.index, prototype)
+  -- Sprite classes use dashes (e.g. "space-location"); prototype tables use underscores.
+  local group = prototypes[string.gsub(class, "%-", "_")]
+  local prototype = group and group[name]
+  if prototype then
+    self.player.open_factoriopedia_gui(prototype)
+  end
 end
 
 --- @param self Gui
@@ -683,8 +683,8 @@ function gui.update_tech_info(self)
         sprite = "item/" .. ingredient.name,
         number = ingredient.amount,
         elem_tooltip = { type = "item", name = ingredient.name },
-        tooltip = show_controls and script.active_mods["RecipeBook"] and { "gui.urq-tooltip-view-in-recipe-book" },
-        handler = { [defines.events.on_gui_click] = gui.open_in_recipe_book },
+        tooltip = show_controls and { "gui.urq-tooltip-view-in-factoriopedia" },
+        handler = { [defines.events.on_gui_click] = gui.open_in_factoriopedia },
       }
     end)
 
@@ -740,8 +740,8 @@ function gui.update_tech_info(self)
       style = "transparent_slot",
       sprite = base .. "/" .. name,
       elem_tooltip = { type = base, name = name },
-      tooltip = show_controls and script.active_mods["RecipeBook"] and { "gui.urq-tooltip-view-in-recipe-book" },
-      handler = { [defines.events.on_gui_click] = gui.open_in_recipe_book },
+      tooltip = show_controls and { "gui.urq-tooltip-view-in-factoriopedia" },
+      handler = { [defines.events.on_gui_click] = gui.open_in_factoriopedia },
     }
     if number and number > 0 then ingredient["number"] = number end
     flib_gui.add(ingredients_table, ingredient)
@@ -756,7 +756,7 @@ function gui.update_tech_info(self)
     table.mapped(technology.prototype.effects, function(effect)
       local template = gui_util.effect_button(effect, show_controls)
       if template ~= nil then
-        template.handler = { [defines.events.on_gui_click] = gui.open_in_recipe_book }
+        template.handler = { [defines.events.on_gui_click] = gui.open_in_factoriopedia }
       end
       return template
     end)

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "UltimateResearchQueue2",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "title": "Ultimate Research Queue for 2.x",
   "description": "Queue technologies for research, see research time ETAs, automatically research all prerequisites, auto-research infinite technologies.",
   "author": "brendanmeyer",
@@ -10,7 +10,6 @@
   "dependencies": [
     "base >= 2.1",
     "flib >= 0.17.1",
-    "? RecipeBook >= 4.0.0",
     "! sonaxaton-research-queue",
     "! UltimateResearchQueue"
   ]

--- a/locale/en/UltimateResearchQueue.cfg
+++ b/locale/en/UltimateResearchQueue.cfg
@@ -24,7 +24,7 @@ urq-tooltip-add-to-queue=\n__CONTROL_STYLE_BEGIN__Double __CONTROL_LEFT_CLICK__:
 urq-tooltip-remove-from-queue=\n__CONTROL_STYLE_BEGIN____CONTROL_RIGHT_CLICK__:__CONTROL_STYLE_END__ Remove from the research queue
 urq-tooltip-title=[font=default-bold][color=255, 230, 192]__1__[/color][/font]
 urq-tooltip-view-details=__CONTROL_STYLE_BEGIN____CONTROL_LEFT_CLICK__:__CONTROL_STYLE_END__ View details
-urq-tooltip-view-in-recipe-book=__CONTROL_STYLE_BEGIN__Alt + __CONTROL_LEFT_CLICK__:__CONTROL_STYLE_END__ View in Recipe Book
+urq-tooltip-view-in-factoriopedia=__CONTROL_STYLE_BEGIN__Alt + __CONTROL_LEFT_CLICK__:__CONTROL_STYLE_END__ View in Factoriopedia
 urq-upgrade-group=Upgrade group
 urq-welcome=[font=default-bold]Welcome to Ultimate Research Queue 2![/font]\n\nClick a technology to view its information in this panel. Click the graph button to view the selected technology in the technology graph.\n\nClick the "auto-requeue multi-level technologies" button to continually research the queued multi-level technologies. Queueing a single technology will research only that technology, and queueing multiple technologies will research the techs in that order before repeating.\n\nOnce you are used to the mod, you can disable the control hints in the per-player mod settings.
 


### PR DESCRIPTION
## Problem

Recipe Book is not being updated for Factorio 2.1, and its users are directed to the base-game Factoriopedia instead. This mod still integrated with Recipe Book: alt+clicking an item/recipe/effect in the technology info panel called `remote.call("RecipeBook", "open_page", ...)`, and both the tooltip hints and the click handlers were gated behind `script.active_mods["RecipeBook"]`.

With Recipe Book gone, that remote interface no longer exists, so alt+clicking items in the mod's UI now does nothing.

## Fix

Replace the Recipe Book integration with the built-in Factoriopedia (`LuaPlayer::open_factoriopedia_gui`, available in base 2.0+):

- `gui.open_in_recipe_book` → `gui.open_in_factoriopedia`. Instead of hardcoding `item`/`recipe`, the handler now maps the button's sprite class to its matching `prototypes` table (converting dashes to underscores, e.g. `space-location` → `space_location`). Items, recipes, entities, fluids, space locations, and qualities all open correctly; unknown classes safely no-op.
- Removed the `script.active_mods["RecipeBook"]` gate from the tooltip hints and handlers since Factoriopedia is always available.
- Locale string `urq-tooltip-view-in-recipe-book` → `urq-tooltip-view-in-factoriopedia` ("View in Factoriopedia").
- Dropped the optional `RecipeBook` dependency from `info.json`.
- Version bump to 2.1.3 with a changelog entry.

The **alt + left-click** control is unchanged, matching the previous UX.

## Notes

The Lua language server may flag `open_factoriopedia_gui` / `e.alt` / `e.element` as "undefined field" — that's just its bundled API definitions lagging behind Factorio 2.1; the method and event fields are real.

🤖 Generated with Claude Code
